### PR TITLE
Fixed up debian init scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DESTDIR:=
 PREFIX := /usr/local
 bindir:=/bin
+sbindir:=/sbin
 
 #CFLAGS=-O0 -g -Wall -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D_BSD_SOURCE
 CFLAGS=-O2 -Wall -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D_BSD_SOURCE
@@ -23,4 +24,4 @@ clean:
 	rm -f *.o statsrelay
 
 install: statsrelay
-	install -D -m 0755 statsrelay $(DESTDIR)$(PREFIX)$(bindir)/statsrelay
+	install -D -m 0755 statsrelay $(DESTDIR)$(PREFIX)$(sbindir)/statsrelay

--- a/debian/init.d
+++ b/debian/init.d
@@ -46,7 +46,9 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+        --make-pidfile \
+        --background -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready


### PR DESCRIPTION
- added --make-pidfile and --background to start-stop-daemon
- added execute bit to debian/init.d so that initscript gets installed
  correctly
- Changed install path of statsrelay to sbindir to make it consistent
  with the install path that the debian initscript is expecting
