### PR TITLE
always use whitespace around statements

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -70,7 +70,7 @@ char *buffer_tail(buffer_t *b)
 char *myrealloc(char *p, size_t old, size_t new)
 {
     char *pnew = malloc(new);
-	if(pnew == NULL) {
+	if (pnew == NULL) {
 		return NULL;
 	}
     memcpy(pnew, p, old);
@@ -125,7 +125,7 @@ int buffer_set(buffer_t *b, const char *data, size_t size)
 
 int buffer_realign(buffer_t *b)
 {
-    if(b->tail != b->head) {
+    if (b->tail != b->head) {
         memmove(b->ptr, b->head, b->tail - b->head);
     }
     /* do not switch the order of the following two statements */

--- a/src/log.c
+++ b/src/log.c
@@ -18,7 +18,7 @@ void stats_log(const char *format, ...) {
 	vsnprintf(buffer, sizeof(buffer), format, args);
 	va_end(args);
 
-	if(g_verbose == 1) {
+	if (g_verbose == 1) {
 		va_start(args, format);
 		vfprintf(stderr, format, args);
 		va_end(args);

--- a/src/main.c
+++ b/src/main.c
@@ -42,20 +42,20 @@ void graceful_shutdown(struct ev_loop *loop, ev_signal *w, int revents) {
 	stats_log("Received signal, shutting down.");
 	ev_break(loop, EVBREAK_ALL);
 
-	if(ts != NULL) {
+	if (ts != NULL) {
 		tcpserver_destroy(ts);
 	}
-	if(us != NULL) {
+	if (us != NULL) {
 		udpserver_destroy(us);
 	}
-	if(server != NULL) {
+	if (server != NULL) {
 		stats_server_destroy(server);
 	}
 }
 
 void reload_config(struct ev_loop *loop, ev_signal *w, int revents) {
 	stats_log("Received SIGHUP, reloading.");
-	if(server != NULL) {
+	if (server != NULL) {
 		stats_server_reload(server);
 	}
 }
@@ -94,10 +94,10 @@ int main(int argc, char **argv) {
 
 	stats_log(PACKAGE_STRING);
 
-	while(c != -1) {
+	while (c != -1) {
 		c = getopt_long(argc, argv, "c:b:vh", long_options, &option_index);
 
-		switch(c) {
+		switch (c) {
 			case -1:
 				break;
 			case 0:
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	if(options.binds == NULL) {
+	if (options.binds == NULL) {
 		address = malloc(2);
 		memcpy(address, "*\0", 2);
 		options.binds = g_list_prepend(options.binds, address);
@@ -147,31 +147,31 @@ int main(int argc, char **argv) {
 
 	server = stats_server_create(options.filename, loop);
 
-	if(server == NULL) {
+	if (server == NULL) {
 		stats_log("main: Unable to create stats_server");
 		return 1;
 	}
 
 	ts = tcpserver_create(loop, server);
-	if(ts == NULL) {
+	if (ts == NULL) {
 		stats_log("main: Unable to create tcpserver");
 		return 3;
 	}
 
 	us = udpserver_create(loop, server);
-	if(us == NULL) {
+	if (us == NULL) {
 		stats_log("main: Unable to create udpserver");
 		return 5;
 	}
 
 	for (l = options.binds; l != NULL; l = l->next) {
 		address = l->data;
-		if(tcpserver_bind(ts, address, "8125", stats_connection, stats_recv) != 0) {
+		if (tcpserver_bind(ts, address, "8125", stats_connection, stats_recv) != 0) {
 			stats_log("main: Unable to bind tcp %s", address);
 			return 6;
 		}
 
-		if(udpserver_bind(us, address, "8125", stats_udp_recv) != 0) {
+		if (udpserver_bind(us, address, "8125", stats_udp_recv) != 0) {
 			stats_log("main: Unable to bind udp %s", address);
 			return 7;
 		}

--- a/src/stathasher.c
+++ b/src/stathasher.c
@@ -71,10 +71,10 @@ int main(int argc, char **argv) {
 	options.filename = "/etc/statsrelay.conf";
 	options.verbose = 0;
 
-	while(c != -1) {
+	while (c != -1) {
 		c = getopt_long(argc, argv, "c:vh", long_options, &option_index);
 
-		switch(c) {
+		switch (c) {
 			case -1:
 				break;
 			case 0:
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
 
 	server = stats_server_create(options.filename, NULL);
 
-	if(server == NULL) {
+	if (server == NULL) {
 		stats_log("main: Unable to create stats_server");
 		return 1;
 	}

--- a/src/stats.c
+++ b/src/stats.c
@@ -69,7 +69,7 @@ stats_server_t *stats_server_create(char *filename, struct ev_loop *loop) {
 	stats_server_t *server;
 
 	server = malloc(sizeof(stats_server_t));
-	if(server == NULL) {
+	if (server == NULL) {
 		stats_log("stats: Unable to allocate memory");
 		free(server);
 		return NULL;
@@ -80,7 +80,7 @@ stats_server_t *stats_server_create(char *filename, struct ev_loop *loop) {
 	server->ketama_cache = g_hash_table_new_full(g_str_hash, g_str_equal, free, NULL);
 
 	server->ketama_filename = filename;
-	if(ketama_roll(&server->kc, filename) == 0) {
+	if (ketama_roll(&server->kc, filename) == 0) {
 		stats_log(ketama_error());
 		stats_log("stats: Unable to load ketama config from %s", filename);
 		free(server);
@@ -117,7 +117,7 @@ void stats_kill_all_backends(stats_server_t *server) {
 	gpointer key, value;
 
 	g_hash_table_iter_init(&iter, server->backends);
-	while(g_hash_table_iter_next(&iter, &key, &value)) {
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
 		stats_kill_backend(server, value);
 		free(value);
 		g_hash_table_iter_remove(&iter);
@@ -125,7 +125,7 @@ void stats_kill_all_backends(stats_server_t *server) {
 }
 
 void stats_server_reload(stats_server_t *server) {
-	if(ketama_roll(&server->kc, server->ketama_filename) == 0) {
+	if (ketama_roll(&server->kc, server->ketama_filename) == 0) {
 		stats_log(ketama_error());
 		stats_log("stats: Unable to reload ketama config from %s", server->ketama_filename);
 	}
@@ -140,12 +140,12 @@ void *stats_connection(int sd, void *ctx) {
 
 	//stats_log("stats: Accepted connection on socket %i", sd);
 	session = (stats_session_t *)malloc(sizeof(stats_session_t));
-	if(session == NULL) {
+	if (session == NULL) {
 		stats_log("stats: Unable to allocate memory");
 		return NULL;
 	}
 
-	if(buffer_init(&session->buffer) != 0) {
+	if (buffer_init(&session->buffer) != 0) {
 		stats_log("stats: Unable to initialize buffer");
 		free(session);
 		return NULL;
@@ -177,7 +177,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 	mcs *ks;
 
 	backend = g_hash_table_lookup(server->ketama_cache, key);
-	if(backend != NULL) {
+	if (backend != NULL) {
 		return backend;
 	}
 
@@ -186,9 +186,9 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 	iplen = sizeof(ks->ip);
 
 	backend = g_hash_table_lookup(server->backends, ip);
-	if(backend == NULL) {
+	if (backend == NULL) {
 		backend = malloc(sizeof(stats_backend_t));
-		if(backend == NULL) {
+		if (backend == NULL) {
 			stats_log("stats: Cannot allocate memory for backend connection");
 			return NULL;
 		}
@@ -199,7 +199,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 		backend->dropped_lines = 0;
 		backend->failing = 0;
 
-		if(tcpclient_init(&backend->client, server->loop, (void *)backend, server->max_send_queue) != 0) {
+		if (tcpclient_init(&backend->client, server->loop, (void *)backend, server->max_send_queue) != 0) {
 			stats_log("stats: Unable to initialize tcpclient");
 			free(backend);
 			return NULL;
@@ -209,7 +209,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 
 		// Make a copy of the address because it's immutableish
 		address = malloc(iplen);
-		if(address == NULL) {
+		if (address == NULL) {
 			stats_log("stats: Unable to allocate memory for backend address");
 			return NULL;
 		}
@@ -217,7 +217,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 		backend->key = address;
 
 		port = memchr(address, ':', iplen);
-		if(port == NULL) {
+		if (port == NULL) {
 			stats_log("stats: Unable to parse server address from config: %s", ip);
 			free(address);
 			return NULL;
@@ -226,7 +226,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 		port++;
 
 		protocol = memchr(port, ':', (port - address));
-		if(protocol != NULL) {
+		if (protocol != NULL) {
 			protocol[0] = '\0';
 			protocol++;
 		}else{
@@ -234,7 +234,7 @@ stats_backend_t *stats_get_backend(stats_server_t *server, char *key, size_t key
 		}
 
 		ret = tcpclient_connect(&backend->client, address, port, protocol);
-		if(ret != 0) {
+		if (ret != 0) {
 			stats_log("stats: Error connecting to [%s]:%s (tcpclient_connect returned %i)", address, port, ret);
 			free(address);
 			return NULL;
@@ -260,12 +260,12 @@ int stats_validate_line(char *line, size_t len) {
 	start = line;
 	plen = len;
 	end = memchr(start, ':', plen);
-	if(end == NULL) {
+	if (end == NULL) {
 		stats_log("stats: Invalid line \"%s\" missing ':'", line);
 		return 1;
 	}
 
-	if((end - start) < 1) {
+	if ((end - start) < 1) {
 		stats_log("stats: Invalid line \"%s\" zero length key", line);
 		return 2;
 	}
@@ -275,7 +275,7 @@ int stats_validate_line(char *line, size_t len) {
 
 	c = end[0];
 	end[0] = '\0';
-	if((strtod(start, &err) == 0.0) && (err == start)) {
+	if ((strtod(start, &err) == 0.0) && (err == start)) {
 		end[0] = c;
 		stats_log("stats: Invalid line \"%s\" unable to parse value as double", line);
 		return 3;
@@ -283,7 +283,7 @@ int stats_validate_line(char *line, size_t len) {
 	end[0] = c;
 
 	end = memchr(start, '|', plen);
-	if(end == NULL) {
+	if (end == NULL) {
 		stats_log("stats: Invalid line \"%s\" missing '|'", line);
 		return 4;
 	}
@@ -292,40 +292,40 @@ int stats_validate_line(char *line, size_t len) {
 	plen = len - (start - line);
 
 	end = memchr(start, '|', plen);
-	if(end != NULL) {
+	if (end != NULL) {
 		c = end[0];
 		end[0] = '\0';
 		plen = end - start;
 	}
 
 	valid = 0;
-	for(i = 0; i < valid_stat_types_len; i++) {
-		if(strlen(valid_stat_types[i]) != plen) {
+	for (i = 0; i < valid_stat_types_len; i++) {
+		if (strlen(valid_stat_types[i]) != plen) {
 			continue;
 		}
-		if(strncmp(start, valid_stat_types[i], plen) == 0) {
+		if (strncmp(start, valid_stat_types[i], plen) == 0) {
 			valid = 1;
 			break;
 		}
 	}
 
-	if(valid == 0) {
+	if (valid == 0) {
 		stats_log("stats: Invalid line \"%s\" unknown stat type \"%s\"", line, start);
 		return 7;
 	}
 
-	if(end != NULL) {
+	if (end != NULL) {
 		end[0] = c;
 		// end[0] is currently the second | char
 		// test if we have at least 1 char following it (@)
-		if((len - (end - line) > 1) && (end[1] == '@')) {
+		if ((len - (end - line) > 1) && (end[1] == '@')) {
 			start = end + 2;
 			plen = len - (start - line);
-			if(plen == 0) {
+			if (plen == 0) {
 				stats_log("stats: Invalid line \"%s\" @ sample with no rate", line);
 				return 5;
 			}
-			if((strtod(start, &err) == 0.0) && err == start) {
+			if ((strtod(start, &err) == 0.0) && err == start) {
 				stats_log("stats: Invalid line \"%s\" invalid sample rate", line);
 				return 6;
 			}
@@ -344,12 +344,12 @@ int stats_relay_line(char *line, size_t len, stats_server_t *ss) {
 
 	line[len] = '\0';
 
-	if(ss->validate_lines == 1 && stats_validate_line(line, len) != 0) {
+	if (ss->validate_lines == 1 && stats_validate_line(line, len) != 0) {
 		return 1;
 	}
 
 	keyend = memchr(line, ':', len);
-	if(keyend == NULL) {
+	if (keyend == NULL) {
 		ss->malformed_lines++;
 		stats_log("stats: dropping malformed line: \"%s\"", line);
 		return 1;
@@ -361,13 +361,13 @@ int stats_relay_line(char *line, size_t len, stats_server_t *ss) {
 	keyend[0] = ':';
 	line[len] = '\n';
 
-	if(backend == NULL) {
+	if (backend == NULL) {
 		return 1;
 	}
 
-	if(tcpclient_sendall(&backend->client, line, len+1) != 0) {
+	if (tcpclient_sendall(&backend->client, line, len+1) != 0) {
 		backend->dropped_lines++;
-		if(backend->failing == 0) {
+		if (backend->failing == 0) {
 			stats_log("stats: Error sending to backend %s", backend->key);
 			backend->failing = 1;
 		}
@@ -417,7 +417,7 @@ void stats_send_statistics(stats_session_t *session) {
 		session->server->malformed_lines));
 
 	g_hash_table_iter_init(&iter, session->server->backends);
-	while(g_hash_table_iter_next(&iter, &key, &value)) {
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
 		backend = (stats_backend_t *)value;
 
 		buffer_produced(response,
@@ -449,14 +449,14 @@ void stats_send_statistics(stats_session_t *session) {
 	buffer_produced(response,
 		snprintf((char *)buffer_tail(response), buffer_spacecount(response), "\n"));
 
-	while(buffer_datacount(response) > 0) {
+	while (buffer_datacount(response) > 0) {
 		bytes_sent = send(session->sd, buffer_head(response), buffer_datacount(response), 0);
-		if(bytes_sent < 0) {
+		if (bytes_sent < 0) {
 			stats_log("stats: Error sending status response: %s", strerror(errno));
 			break;
 		}
 
-		if(bytes_sent == 0) {
+		if (bytes_sent == 0) {
 			stats_log("stats: Error sending status response: Client closed connection");
 			break;
 		}
@@ -470,17 +470,17 @@ int stats_process_lines(stats_session_t *session) {
 	char *head, *tail;
 	size_t len;
 
-	while(buffer_datacount(&session->buffer) > 0) {
+	while (buffer_datacount(&session->buffer) > 0) {
 		head = (char *)buffer_head(&session->buffer);
 		tail = memchr(head, '\n', buffer_datacount(&session->buffer));
 
-		if(tail == NULL) {
+		if (tail == NULL) {
 			break;
 		}
 
 		len = tail - head;
 
-		if(len >= 6 && memcmp(head, "status\n", 7) == 0) {
+		if (len >= 6 && memcmp(head, "status\n", 7) == 0) {
 			stats_send_statistics(session);
 		}else{
 			stats_relay_line(head, len, session->server);
@@ -505,11 +505,11 @@ int stats_recv(int sd, void *data, void *ctx) {
 	// First we try to realign the buffer (memmove so that head and ptr match)
 	// If that fails, we double the size of the buffer
 	space = buffer_spacecount(&session->buffer);
-	if(space == 0) {
+	if (space == 0) {
 		buffer_realign(&session->buffer);
 		space = buffer_spacecount(&session->buffer);
-		if(space == 0) {
-			if(buffer_expand(&session->buffer) != 0) {
+		if (space == 0) {
+			if (buffer_expand(&session->buffer) != 0) {
 				stats_log("stats: Unable to expand buffer, aborting");
 				stats_session_destroy(session);
 				return 1;
@@ -519,13 +519,13 @@ int stats_recv(int sd, void *data, void *ctx) {
 	}
 
 	bytes_read = recv(sd, buffer_tail(&session->buffer), space, 0);
-	if(bytes_read < 0) {
+	if (bytes_read < 0) {
 		stats_log("stats: Error receiving from socket: %s", strerror(errno));
 		stats_session_destroy(session);
 		return 2;
 	}
 
-	if(bytes_read == 0) {
+	if (bytes_read == 0) {
 		//stats_log("stats: Client closed connection");
 		stats_session_destroy(session);
 		return 3;
@@ -533,13 +533,13 @@ int stats_recv(int sd, void *data, void *ctx) {
 
 	session->server->bytes_recv_tcp += bytes_read;
 
-	if(buffer_produced(&session->buffer, bytes_read) != 0) {
+	if (buffer_produced(&session->buffer, bytes_read) != 0) {
 		stats_log("stats: Unable to produce buffer by %i bytes, aborting", bytes_read);
 		stats_session_destroy(session);
 		return 4;
 	}
 
-	if(stats_process_lines(session) != 0) {
+	if (stats_process_lines(session) != 0) {
 		stats_log("stats: Invalid line processed, closing connection");
 		stats_session_destroy(session);
 		return 5;
@@ -559,14 +559,14 @@ int stats_udp_recv(int sd, void *data) {
 
 	bytes_read = read(sd, buffer_head(buffer), MAX_UDP_LENGTH);
 
-	if(bytes_read == 0) {
+	if (bytes_read == 0) {
 		delete_buffer(buffer);
 		stats_log("stats: Got zero-length UDP payload. That's weird.");
 		return 1;
 	}
 
-	if(bytes_read < 0) {
-		if(errno == EAGAIN) {
+	if (bytes_read < 0) {
+		if (errno == EAGAIN) {
 			delete_buffer(buffer);
 			return 0;
 		}else{
@@ -579,16 +579,16 @@ int stats_udp_recv(int sd, void *data) {
 	buffer_produced(buffer, bytes_read);
 	ss->bytes_recv_udp += bytes_read;
 
-	while(buffer_datacount(buffer) > 0) {
+	while (buffer_datacount(buffer) > 0) {
 		head = (char *)buffer_head(buffer);
 		tail = memchr(head, '\n', buffer_datacount(buffer));
 		len = tail - head;
 
-		if(tail == NULL) {
+		if (tail == NULL) {
 			break;
 		}
 
-		if(stats_relay_line(head, len, ss) != 0) {
+		if (stats_relay_line(head, len, ss) != 0) {
 			delete_buffer(buffer);
 			return 3;
 		}
@@ -596,8 +596,8 @@ int stats_udp_recv(int sd, void *data) {
 	}
 
 	len = buffer_datacount(buffer);
-	if(len > 0) {
-		if(stats_relay_line(buffer_head(buffer), len, ss) != 0) {
+	if (len > 0) {
+		if (stats_relay_line(buffer_head(buffer), len, ss) != 0) {
 			delete_buffer(buffer);
 			return 4;
 		}

--- a/src/tcpserver.c
+++ b/src/tcpserver.c
@@ -55,7 +55,7 @@ void tcplistener_accept_callback(struct ev_loop *loop, struct ev_io *watcher, in
 	tcpsession_t *session;
 	int err;
 
-	if(revents & EV_ERROR) {
+	if (revents & EV_ERROR) {
 		// ev(3) says this is an error of "unspecified" type, so
 		// that's bloody useful.
 		stats_log("tcplistener: libev server socket error");
@@ -64,20 +64,20 @@ void tcplistener_accept_callback(struct ev_loop *loop, struct ev_io *watcher, in
 
 	listener = (tcplistener_t *)watcher->data;
 	session = tcpsession_create(listener);
-	if(session == NULL) {
+	if (session == NULL) {
 		stats_log("tcplistener: Unable to allocate tcpsession, not calling accept()");
 		return;
 	}
 
 	sin_size = sizeof(session->client_addr);
 	session->sd = accept(watcher->fd, (struct sockaddr *)&session->client_addr, &sin_size);
-	if(session->sd < 0) {
+	if (session->sd < 0) {
 		stats_log("tcplistener: Error accepting connection: %s", strerror(errno));
 		return;
 	}
 
 	err = fcntl(session->sd, F_SETFL, (fcntl(session->sd, F_GETFL) | O_NONBLOCK));
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcplistener: Error setting socket to non-blocking: %s", strerror(errno));
 		return;
 	}
@@ -94,7 +94,7 @@ void tcplistener_accept_callback(struct ev_loop *loop, struct ev_io *watcher, in
 void tcpsession_recv_callback(struct ev_loop *loop, struct ev_io *watcher, int revents) {
 	tcpsession_t *session;
 
-	if(revents & EV_ERROR) {
+	if (revents & EV_ERROR) {
 		// ev(3) says this is an error of "unspecified" type, so
 		// that's bloody useful.
 		stats_log("tcpsession: libev server socket error");
@@ -102,17 +102,17 @@ void tcpsession_recv_callback(struct ev_loop *loop, struct ev_io *watcher, int r
 	}
 
 	session = (tcpsession_t *)watcher->data;
-	if(session == NULL) {
+	if (session == NULL) {
 		stats_log("tcpsession: Unable to determine tcpsession, not calling recv callback");
 		return;
 	}
 
-	if(session->cb_recv == NULL) {
+	if (session->cb_recv == NULL) {
 		stats_log("tcpsession: No recv callback registered for session, ignoring event");
 		return;
 	}
 
-	if(session->cb_recv(session->sd, session->data, session->ctx) != 0) {
+	if (session->cb_recv(session->sd, session->data, session->ctx) != 0) {
 		//stats_log("tcpsession: recv callback returned non-zero, closing connection");
 		tcpsession_destroy(session);
 		return;
@@ -124,12 +124,12 @@ tcpsession_t *tcpsession_create(tcplistener_t *listener) {
 	tcpsession_t *session;
 
 	session = malloc(sizeof(tcpsession_t));
-	if(session == NULL) {
+	if (session == NULL) {
 		return NULL;
 	}
 
 	session->watcher = malloc(sizeof(struct ev_io));
-	if(session->watcher == NULL) {
+	if (session->watcher == NULL) {
 		free(session);
 		return NULL;
 	}
@@ -143,7 +143,7 @@ tcpsession_t *tcpsession_create(tcplistener_t *listener) {
 }
 
 void tcpsession_destroy(tcpsession_t *session) {
-	if(session->sd > 0) {
+	if (session->sd > 0) {
 		close(session->sd);
 	}
 	ev_io_stop(session->loop, session->watcher);
@@ -184,7 +184,7 @@ tcplistener_t *tcplistener_create(tcpserver_t *server, struct addrinfo *addr, vo
 				addr->ai_protocol);
 
 	memset(addr_string, 0, INET6_ADDRSTRLEN);
-	if(addr->ai_family == AF_INET) {
+	if (addr->ai_family == AF_INET) {
 		struct sockaddr_in *ipv4 = (struct sockaddr_in *)addr->ai_addr;
 		ip = &(ipv4->sin_addr);
 		port = ntohs(ipv4->sin_port);
@@ -193,41 +193,41 @@ tcplistener_t *tcplistener_create(tcpserver_t *server, struct addrinfo *addr, vo
 		ip = &(ipv6->sin6_addr);
 		port = ntohs(ipv6->sin6_port);
 	}
-	if(inet_ntop(addr->ai_family, ip, addr_string, addr->ai_addrlen) == NULL) {
+	if (inet_ntop(addr->ai_family, ip, addr_string, addr->ai_addrlen) == NULL) {
 		stats_log("tcplistener: Unable to format network address string");
 		free(listener);
 		return NULL;
 	}
 
-	if(listener->sd < 0) {
+	if (listener->sd < 0) {
 		stats_log("tcplistener: Error creating socket %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = setsockopt(listener->sd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcplistener: Error setting SO_REUSEADDR on %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = fcntl(listener->sd, F_SETFL, (fcntl(listener->sd, F_GETFL) | O_NONBLOCK));
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcplistener: Error setting socket to non-blocking for %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = bind(listener->sd, addr->ai_addr, addr->ai_addrlen);
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcplistener: Error binding socket for %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = listen(listener->sd, LISTEN_BACKLOG);
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcplistener: Error listening to socket %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
@@ -244,7 +244,7 @@ tcplistener_t *tcplistener_create(tcpserver_t *server, struct addrinfo *addr, vo
 
 
 void tcplistener_destroy(tcpserver_t *server, tcplistener_t *listener) {
-	if(listener->watcher != NULL) {
+	if (listener->watcher != NULL) {
 		ev_io_stop(server->loop, listener->watcher);
 		free(listener->watcher);
 	}
@@ -264,14 +264,14 @@ int tcpserver_bind(tcpserver_t *server, char *address_and_port, char *default_po
 
 	address = address_and_port;
 	ptr = strrchr(address_and_port, ':');
-	if(ptr == NULL) {
+	if (ptr == NULL) {
 		port = default_port;
 	}else{
 		ptr[0] = '\0';
 		port = ptr + 1;
 	}
 
-	if(address[0] == '*') {
+	if (address[0] == '*') {
 		address = NULL;
 	}
 
@@ -282,22 +282,22 @@ int tcpserver_bind(tcpserver_t *server, char *address_and_port, char *default_po
 	hints.ai_flags = AI_PASSIVE;
 
 	err = getaddrinfo(address, port, &hints, &addrs);
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("tcpserver: getaddrinfo error: %s", gai_strerror(err));
 		return 1;
 	}
 
-	for(p = addrs; p != NULL; p = p->ai_next) {
-		if(server->listeners_len >= MAX_TCP_HANDLERS) {
+	for (p = addrs; p != NULL; p = p->ai_next) {
+		if (server->listeners_len >= MAX_TCP_HANDLERS) {
 			stats_log("tcpserver: Unable to create more than %i TCP listeners", MAX_TCP_HANDLERS);
 			freeaddrinfo(addrs);
 			return 1;
 		}
-		if((address == NULL) && (p->ai_family != AF_INET6)) {
+		if ((address == NULL) && (p->ai_family != AF_INET6)) {
 			continue;
 		}
 		listener = tcplistener_create(server, p, cb_conn, cb_recv);
-		if(listener == NULL) {
+		if (listener == NULL) {
 			continue;
 		}
 		server->listeners[server->listeners_len] = listener;
@@ -305,7 +305,7 @@ int tcpserver_bind(tcpserver_t *server, char *address_and_port, char *default_po
 		ev_io_start(server->loop, listener->watcher);
 	}
 
-	if(port != default_port) {
+	if (port != default_port) {
 		port--;
 		port[0] = ':';
 	}
@@ -318,7 +318,7 @@ int tcpserver_bind(tcpserver_t *server, char *address_and_port, char *default_po
 void tcpserver_destroy(tcpserver_t *server) {
 	int i;
 
-	for(i = 0; i < server->listeners_len; i++) {
+	for (i = 0; i < server->listeners_len; i++) {
 		tcplistener_destroy(server, server->listeners[i]);
 	}
 	free(server);

--- a/src/udpserver.c
+++ b/src/udpserver.c
@@ -50,12 +50,12 @@ void udplistener_recv_callback(struct ev_loop *loop, struct ev_io *watcher, int 
 	udplistener_t *listener;
 	listener = (udplistener_t *)watcher->data;
 
-	if(revents & EV_ERROR) {
+	if (revents & EV_ERROR) {
 		stats_log("udplistener: libev server socket error");
 		return;
 	}
 
-	if(listener->cb_recv(listener->sd, listener->data) != 0) {
+	if (listener->cb_recv(listener->sd, listener->data) != 0) {
 		//stats_log("udplistener: recv callback returned non-zero");
 		return;
 	}
@@ -79,7 +79,7 @@ udplistener_t *udplistener_create(udpserver_t *server, struct addrinfo *addr, in
 				addr->ai_protocol);
 
 	memset(addr_string, 0, INET6_ADDRSTRLEN);
-	if(addr->ai_family == AF_INET) {
+	if (addr->ai_family == AF_INET) {
 		struct sockaddr_in *ipv4 = (struct sockaddr_in *)addr->ai_addr;
 		ip = &(ipv4->sin_addr);
 		port = ntohs(ipv4->sin_port);
@@ -88,34 +88,34 @@ udplistener_t *udplistener_create(udpserver_t *server, struct addrinfo *addr, in
 		ip = &(ipv6->sin6_addr);
 		port = ntohs(ipv6->sin6_port);
 	}
-	if(inet_ntop(addr->ai_family, ip, addr_string, addr->ai_addrlen) == NULL) {
+	if (inet_ntop(addr->ai_family, ip, addr_string, addr->ai_addrlen) == NULL) {
 		stats_log("udplistener: Unable to format network address string");
 		free(listener);
 		return NULL;
 	}
 
-	if(listener->sd < 0) {
+	if (listener->sd < 0) {
 		stats_log("udplistener: Error creating socket %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = setsockopt(listener->sd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("udplistener: Error setting SO_REUSEADDR on %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = fcntl(listener->sd, F_SETFL, (fcntl(listener->sd, F_GETFL) | O_NONBLOCK));
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("udplistener: Error setting socket to non-blocking for %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
 	}
 
 	err = bind(listener->sd, addr->ai_addr, addr->ai_addrlen);
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("udplistener: Error binding socket for %s[:%i]: %s", addr_string, port, strerror(errno));
 		free(listener);
 		return NULL;
@@ -132,7 +132,7 @@ udplistener_t *udplistener_create(udpserver_t *server, struct addrinfo *addr, in
 
 
 void udplistener_destroy(udpserver_t *server, udplistener_t *listener) {
-	if(listener->watcher != NULL) {
+	if (listener->watcher != NULL) {
 		ev_io_stop(server->loop, listener->watcher);
 		free(listener->watcher);
 	}
@@ -152,14 +152,14 @@ int udpserver_bind(udpserver_t *server, char *address_and_port, char *default_po
 
 	address = address_and_port;
 	ptr = strrchr(address_and_port, ':');
-	if(ptr == NULL) {
+	if (ptr == NULL) {
 		port = default_port;
 	}else{
 		ptr[0] = '\0';
 		port = ptr + 1;
 	}
 
-	if(address[0] == '*') {
+	if (address[0] == '*') {
 		address = NULL;
 	}
 
@@ -170,22 +170,22 @@ int udpserver_bind(udpserver_t *server, char *address_and_port, char *default_po
 	hints.ai_flags = AI_PASSIVE;
 
 	err = getaddrinfo(address, port, &hints, &addrs);
-	if(err != 0) {
+	if (err != 0) {
 		stats_log("udpserver: getaddrinfo error: %s", gai_strerror(err));
 		return 1;
 	}
 
-	for(p = addrs; p != NULL; p = p->ai_next) {
-		if(server->listeners_len >= MAX_UDP_HANDLERS) {
+	for (p = addrs; p != NULL; p = p->ai_next) {
+		if (server->listeners_len >= MAX_UDP_HANDLERS) {
 			stats_log("udpserver: Unable to create more than %i UDP listeners", MAX_UDP_HANDLERS);
 			freeaddrinfo(addrs);
 			return 1;
 		}
-		if((address == NULL) && (p->ai_family != AF_INET6)) {
+		if ((address == NULL) && (p->ai_family != AF_INET6)) {
 			continue;
 		}
 		listener = udplistener_create(server, p, cb_recv);
-		if(listener == NULL) {
+		if (listener == NULL) {
 			continue;
 		}
 		server->listeners[server->listeners_len] = listener;
@@ -201,7 +201,7 @@ int udpserver_bind(udpserver_t *server, char *address_and_port, char *default_po
 void udpserver_destroy(udpserver_t *server) {
 	int i;
 
-	for(i = 0; i < server->listeners_len; i++) {
+	for (i = 0; i < server->listeners_len; i++) {
 		udplistener_destroy(server, server->listeners[i]);
 	}
 	//ev_break(server->loop, EVBREAK_ALL);


### PR DESCRIPTION
Right now the code is not consistent about whether or not it uses whitespace around statements. The code uses both of the following styles:

``` c
if(somecond == 1) {
```

as well as

``` c
if (somecond == 1) {
```

However, for function invocation the style is always:

``` c
foo(arg1, arg2, ...);
```

I think it's necessary to choose a style and stick to it. I strongly recommend using spaces around the builtin statements (`if`, `for`, `while`, `switch`) to make them visually distinct from function invocation. This is the convention used in most of the C projects I've worked with in the past.
