### PR TITLE
teach stats_log how to do dynamic memory allocation

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -2,30 +2,90 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <syslog.h>
 
-int g_verbose = 1;
+#define STATSRELAY_LOG_BUF_SIZE 256
+
+static int g_verbose = 1;
+
+static int fmt_buf_size = 0;
+static char *fmt_buf = NULL;
 
 void stats_log_verbose(int verbose) {
 	g_verbose = verbose;
 }
 
 void stats_log(const char *format, ...) {
-	va_list args;
-	char buffer[MAX_LOG_SIZE];
+	int fmt_len;
+	va_list ap;
+	char *np;
+	size_t total_written, bw;
 
-	va_start(args, format);
-	vsnprintf(buffer, sizeof(buffer), format, args);
-	va_end(args);
-
-	if (g_verbose == 1) {
-		va_start(args, format);
-		vfprintf(stderr, format, args);
-		va_end(args);
-		fprintf(stderr, "\n");
+	// Allocate the format buffer on the first log call
+	if (fmt_buf == NULL) {
+		if ((fmt_buf = malloc(STATSRELAY_LOG_BUF_SIZE)) == NULL) {
+			goto alloc_failure;
+		}
+		fmt_buf_size = STATSRELAY_LOG_BUF_SIZE;
 	}
 
-	va_start(args, format);
-	vsyslog(LOG_INFO, format, args);
-	va_end(args);
+	// Keep trying to vsnprintf until we have a sufficiently sized buffer
+	// allocated.
+	while (1) {
+		va_start(ap, format);
+		fmt_len = vsnprintf(fmt_buf, fmt_buf_size, format, ap);
+		va_end(ap);
+
+		if (fmt_len < 0) {
+			return;  // output error (shouldn't happen for vs* functions)
+		} else if (fmt_len < fmt_buf_size) {
+			break;  // vsnprintf() didn't truncate
+		}
+
+		fmt_buf_size <<= 1;  // double size
+
+		if ((np = realloc(fmt_buf, fmt_buf_size)) == NULL) {
+			goto alloc_failure;
+		}
+		fmt_buf = np;
+	}
+
+	if (g_verbose == 1) {
+		total_written = 0;
+		while (total_written < fmt_len) {
+			// try to write to stderr, but if there are any
+			// failures (e.g. parent had closed stderr) then just
+			// proceed to the syslog call
+			bw = fwrite(fmt_buf + total_written, sizeof(char), fmt_len - total_written, stderr);
+			if (bw <= 0) {
+				break;
+			}
+			total_written += bw;
+		}
+		if (total_written >= fmt_len) {
+			fputc('\n', stderr);
+		}
+	}
+
+	syslog(LOG_INFO, fmt_buf, fmt_len);
+
+	if (fmt_buf_size > STATSRELAY_LOG_BUF_SIZE) {
+		if ((np = realloc(fmt_buf, STATSRELAY_LOG_BUF_SIZE)) == NULL) {
+			goto alloc_failure;
+		}
+		fmt_buf = np;
+		fmt_buf_size = STATSRELAY_LOG_BUF_SIZE;
+	}
+	return;
+
+alloc_failure:
+	stats_log_end();  // reset everything
+	return;
+}
+
+void stats_log_end(void) {
+	free(fmt_buf);
+	fmt_buf = NULL;
+	fmt_buf_size = 0;
 }

--- a/src/log.h
+++ b/src/log.h
@@ -1,9 +1,14 @@
-#ifndef LOG_H
-#define LOG_H
+#ifndef STATSRELAY_LOG_H
+#define STATSRELAY_LOG_H
 
-#define MAX_LOG_SIZE 4096
-
+// set verbose logging, i.e. send logs to stderr
 void stats_log_verbose(int verbose);
+
+// log a message
 void stats_log(const char *format, ...);
+
+// finish logging; this ensures that the internally allocated buffer is freed;
+// it can safely be called multiple times
+void stats_log_end(void);
 
 #endif

--- a/src/stathasher.c
+++ b/src/stathasher.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
         input = fopen(argv[optind], "r");
         if (input == NULL) {
             printf("Could not open %s", argv[optind]);
+            stats_log_end();
             return 1;
         }
     }
@@ -116,5 +117,6 @@ int main(int argc, char **argv) {
         free(lineptr);
         lineptr = NULL;
     }
+	stats_log_end();
 	return 0;
 }


### PR DESCRIPTION
This redoes the logging implementation so that it only does memory allocation on the first log message, and on subsequent log messages that are > 256 bytes.

The logger can still log messages of arbitrary size.
