### PR TITLE
silence _BSD_SOURCE deprecation warnings in GCC 4.9+

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS=-O2 -g -std=c99 -pedantic -Wall -fno-strict-aliasing -D_XOPEN_SOURCE=600 -D_BSD_SOURCE $(GLIB_CFLAGS)
+AM_CFLAGS=-O2 -g -std=c99 -pedantic -Wall -fno-strict-aliasing -D_XOPEN_SOURCE=600 -D_DEFAULT_SOURCE $(GLIB_CFLAGS)
 AM_LDFLAGS=-lcrypto -lev -lm $(GLIB_LDFLAGS)
 bin_PROGRAMS=statsrelay stathasher
 statsrelay_SOURCES=buffer.c ketama.c log.c tcpclient.c tcpserver.c udpserver.c stats.c main.c


### PR DESCRIPTION
This makes GCC 4.9+ compile the code without warnings. It works fine in GCC 4.6 which is as far back as I was able/willing to test.
