### PR TITLE
flush stdout explicitly in stathasher, so it works better with bidirectional pipes

### DIFF
--- a/src/stathasher.c
+++ b/src/stathasher.c
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
 			printf(" statsd=%s statsd_shard=%d", choice, shard);
 		}
 		putchar('\n');
+		fflush(stdout);
 	}
 	hashring_dealloc(carbon_ring);
 	hashring_dealloc(statsd_ring);


### PR DESCRIPTION
This is necessary to have a bidirectional pipe with stathasher, since otherwise printf is detecting it's talking to a pipe and tries to do buffered output.
