### PR TITLE
make stathasher use getopt and pass vaglrind

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -28,8 +28,6 @@ static struct option long_options[] = {
 	{"help",		no_argument,		NULL, 'h'},
 };
 
-static const char default_config[] = "/etc/statsrelay.yaml";
-
 static void graceful_shutdown(struct ev_loop *loop, ev_signal *w, int revents) {
 	stats_log("Received signal, shutting down.");
 	destroy_server_collection(&servers);
@@ -83,14 +81,13 @@ static void print_help(const char *argv0) {
 int main(int argc, char **argv) {
 	ev_signal sigint_watcher, sigterm_watcher, sighup_watcher;
 	char *lower;
-	int option_index = 0;
 	char c = 0;
 	bool just_check_config = false;
 	servers.initialized = false;
 
 	stats_set_log_level(STATSRELAY_LOG_INFO);  // set default value
 	while (c != -1) {
-		c = getopt_long(argc, argv, "t:c:l:vh", long_options, &option_index);
+		c = getopt_long(argc, argv, "t:c:l:vh", long_options, NULL);
 		switch (c) {
 		case -1:
 			break;

--- a/src/stathasher.c
+++ b/src/stathasher.c
@@ -1,31 +1,60 @@
+#include <ctype.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "./hashring.h"
 #include "./yaml_config.h"
+
+static struct option long_options[] = {
+	{"config",		required_argument,	NULL, 'c'},
+	{"help",		no_argument,		NULL, 'h'},
+};
 
 static void* my_strdup(const char *str, void *unused_data) {
 	return strdup(str);
 }
 
+static void print_help(const char *argv0) {
+	printf("Usage: %s [-h] [-c /path/to/config.yaml]", argv0);
+}
+
 int main(int argc, char **argv) {
-	if (argc != 2) {
-		fprintf(stderr, "usage: %s /path/to/hash.txt\n", argv[0]);
+	char *config_name = (char *) default_config;
+	char c = 0;
+	while (c != -1) {
+		c = getopt_long(argc, argv, "c:h", long_options, NULL);
+		switch (c) {
+		case -1:
+			break;
+		case 0:
+		case 'h':
+			print_help(argv[0]);
+			return 0;
+		case 'c':
+			config_name = optarg;
+			break;
+		default:
+			printf("%s: Unknown argument %c\n", argv[0], c);
+			return 1;
+		}
+	}
+	if (optind != 1 && optind != 3) {
+		printf("%s: unexpected command optoins\n", argv[0]);
 		return 1;
 	}
 
-	FILE *config_file = fopen(argv[1], "r");
+	FILE *config_file = fopen(config_name, "r");
 	if (config_file == NULL) {
-		fprintf(stderr, "failed to open %s\n", argv[1]);
+		fprintf(stderr, "failed to open %s\n", config_name);
 		return 1;
 	}
 	struct config *app_cfg = parse_config(config_file);
 
 	fclose(config_file);
 	if (app_cfg == NULL) {
-		fprintf(stderr, "failed to parse config %s\n", argv[1]);
+		fprintf(stderr, "failed to parse config %s\n", config_name);
 		return 1;
 	}
 
@@ -66,6 +95,7 @@ int main(int argc, char **argv) {
 		putchar('\n');
 		fflush(stdout);
 	}
+	free(line);
 	hashring_dealloc(carbon_ring);
 	hashring_dealloc(statsd_ring);
 	return 0;

--- a/src/yaml_config.h
+++ b/src/yaml_config.h
@@ -20,6 +20,9 @@ struct config {
 	struct proto_config carbon_config;
 };
 
+
+static const char default_config[] = "/etc/statsrelay.yaml";
+
 struct config* parse_config(FILE *input);
 
 // release the memory associated with a config


### PR DESCRIPTION
some small changes: 
- stathasher now uses getopt for option parsing, and can read `/etc/statsrelay.yaml` by default
- stathasher now passes valgrind (previously it didn't `free` the string buffer it used to read from stdin)
- remove the unused option index in statsrelay
