### PR TITLE
we can't free the config object in main until after the event loop is sh...

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
 	char *lower;
 	char c = 0;
 	bool just_check_config = false;
+	struct config *cfg = NULL;
 	servers.initialized = false;
 
 	stats_set_log_level(STATSRELAY_LOG_INFO);  // set default value
@@ -136,17 +137,15 @@ int main(int argc, char **argv) {
 		init_server_collection(&servers, default_config);
 	}
 
-	struct config *cfg = load_config(servers.config_file);
+	cfg = load_config(servers.config_file);
 	if (cfg == NULL) {
 		stats_error_log("failed to parse config");
 		goto err;
 	}
 	if (just_check_config) {
-		destroy_config(cfg);
 		goto success;
 	}
 	bool worked = connect_server_collection(&servers, cfg);
-	destroy_config(cfg);
 	if (!worked) {
 		goto err;
 	}
@@ -166,11 +165,13 @@ int main(int argc, char **argv) {
 
 success:
 	destroy_server_collection(&servers);
+	destroy_config(cfg);
 	stats_log_end();
 	return 0;
 
 err:
 	destroy_server_collection(&servers);
+	destroy_config(cfg);
 	stats_log_end();
 	return 1;
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -435,7 +435,7 @@ static int stats_process_lines(stats_session_t *session) {
 		memcpy(line_buffer, head, len);
 		memcpy(line_buffer + len, "\n\0", 2);
 
-		if (strcmp(line_buffer, "status\n") == 0) {
+		if (len == 6 && strcmp(line_buffer, "status\n") == 0) {
 			stats_send_statistics(session);
 		} else if (stats_relay_line(line_buffer, len, session->server) != 0) {
 			return 1;

--- a/src/yaml_config.c
+++ b/src/yaml_config.c
@@ -218,9 +218,11 @@ parse_err:
 }
 
 void destroy_config(struct config *config) {
-	statsrelay_list_destroy_full(config->carbon_config.ring);
-	free(config->carbon_config.bind);
-	statsrelay_list_destroy_full(config->statsd_config.ring);
-	free(config->statsd_config.bind);
-	free(config);
+	if (config != NULL) {
+		statsrelay_list_destroy_full(config->carbon_config.ring);
+		free(config->carbon_config.bind);
+		statsrelay_list_destroy_full(config->statsd_config.ring);
+		free(config->statsd_config.bind);
+		free(config);
+	}
 }


### PR DESCRIPTION
This fixes statsrelay where it was reading invalid memory when it was reading the config object. This was causing a bunch of mayhem in production.