### PR TITLE
directly use the return value of statsrelay_list_expand

### DIFF
--- a/src/hashring.c
+++ b/src/hashring.c
@@ -63,13 +63,14 @@ bool hashring_add(hashring_t ring, const char *line) {
 	}
 
 	// grow the list
-	if (statsrelay_list_expand(ring->backends) == NULL) {
+	void **new_obj = statsrelay_list_expand(ring->backends);
+	if (new_obj == NULL) {
 		stats_error_log("hashring: failed to expand list");
 		ring->dealloc(obj);
 		goto add_err;
 	}
 
-	ring->backends->data[ring->backends->size - 1] = obj;
+	*new_obj = obj;
 	return true;
 
 add_err:

--- a/src/list.c
+++ b/src/list.c
@@ -14,7 +14,7 @@ list_t statsrelay_list_new() {
 	return list;
 }
 
-void* statsrelay_list_expand(list_t list) {
+void** statsrelay_list_expand(list_t list) {
 	size_t index = list->size;
 	list->size++;
 

--- a/src/list.h
+++ b/src/list.h
@@ -16,7 +16,7 @@ list_t statsrelay_list_new();
 
 // get the address for a new item in the list, and ensure its size is
 // expanded
-void *statsrelay_list_expand(list_t list);
+void **statsrelay_list_expand(list_t list);
 
 // deallocate the list
 void statsrelay_list_destroy(list_t list);

--- a/src/yaml_config.c
+++ b/src/yaml_config.c
@@ -188,11 +188,12 @@ struct config* parse_config(FILE *input) {
 						goto parse_err;
 					}
 				} else {
-					if (statsrelay_list_expand(protoc->ring) == NULL) {
+					char **data_ptr = (char **) statsrelay_list_expand(protoc->ring);
+					if (data_ptr == NULL) {
 						stats_error_log("unable to expand list");
 						goto parse_err;
 					}
-					if ((protoc->ring->data[protoc->ring->size - 1]  = strdup(strval)) == NULL) {
+					if ((*data_ptr  = strdup(strval)) == NULL) {
 						stats_error_log("failed to copy string");
 						goto parse_err;
 					}


### PR DESCRIPTION
With 7f5333c7a0ff6df807e9abe9748908a6b42b4957 I fixed the bug whereby `statsrelay_list_expand` was returning the wrong address (note: the old code was valid because `statsrelay_list_expand` still returned NULL in the right cases, but the non-NULL case had the wrong offset). This change uses the return value of `statsrelay_list_expand` directly, rather than computing the offset, which is slightly more efficient.