### PR TITLE
Fixes for building on centos 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_INIT([statsrelay], m4_esyscmd([tr -d '\n' < VERSION]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([


### PR DESCRIPTION
Current version of tooling on centos 7 complains about missing AM_PROG_CC_C_O