### PR TITLE
Modernize our autoconf setup to actually check for the right deps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ autom4te.cache/
 compile
 config.*
 configure
+configure.scan
 core.*
 depcomp
 install-sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,4 @@
 SUBDIRS=src
+EXTRA_DIST = autogen.sh
+
 dist_doc_DATA=README.md LICENSE*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies:
 ```
 apt-get install automake pkg-config libev-dev libyaml-devel
 
-autoreconf --install
+./autogen.sh
 ./configure
 make clean
 make

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+autoreconf --install

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,12 @@
 AC_PREREQ([2.68])
 AC_INIT([statsrelay], m4_esyscmd([tr -d '\n' < VERSION]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
-AC_PROG_CC
-AM_PROG_CC_C_O
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
+AM_PROG_CC_C_O
 
 # Checks for libraries.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,39 @@
+AC_PREREQ([2.69])
 AC_INIT([statsrelay], m4_esyscmd([tr -d '\n' < VERSION]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_FILES([
- Makefile
- src/Makefile
-])
+
+# Checks for programs.
+AC_PROG_CC
+
+# Checks for libraries.
+
+# Checks for header files.
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_CHECK_HEADER_STDBOOL
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_TYPE_SSIZE_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+AC_TYPE_UINT8_T
+
+# Checks for library functions.
+AC_FUNC_ERROR_AT_LINE
+AC_FUNC_FORK
+AC_FUNC_MALLOC
+AC_FUNC_REALLOC
+AC_FUNC_STRTOD
+AC_CHECK_FUNCS([gettimeofday memchr memmove memset socket strchr strdup strerror strndup strrchr strtol])
+
+AC_CONFIG_FILES([Makefile
+                 src/Makefile])
 AC_CHECK_LIB([ev], [ev_run])
 AC_CHECK_LIB([yaml], [yaml_parser_initialize])
 AC_REVISION([m4_esyscmd_s([git describe --always])])

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,6 @@ AC_PROG_CC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 AC_INIT([statsrelay], m4_esyscmd([tr -d '\n' < VERSION]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_CC


### PR DESCRIPTION
This mostly fixes our autotools, and adds an `autogen.sh` to re-generate the `./configure` script.

This is still not 100% correct, `configure.ac` still doesn't check for the proper headers, but this is a big improvement over the previous version.