### PR TITLE
check that we have the headers for libev/libyaml

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ AM_PROG_CC_C_O
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h])
+AC_CHECK_HEADERS([ev.h], [], [AC_MSG_ERROR([unable to find header ev.h])])
+AC_CHECK_HEADERS([yaml.h], [], [AC_MSG_ERROR([unable to find header yaml.h])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_PID_T


### PR DESCRIPTION
The configure script already checks that libev and libyaml are
installed, but doesn't actually check that the headers are present. This
fixes that.